### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/614868001.svg)](https://zenodo.org/badge/latestdoi/614868001)
 
-# A modified version of PETPrep for already-provided rCPS maps
+# A modified version of PETPrep-matlab for already-provided rCPS maps
 
-This repository/codebase was used to prepare provided rates of cerebral protein synthesis (rCPS) derivative files into individually processed statistical maps per participant. It was built from a modified PETPrep pipeline to accommodate skipping some of the first steps since rCPS files were already provided to this pipeline and we did not want to re-create them.
+This repository/codebase was used to prepare provided rates of cerebral protein synthesis (rCPS) derivative files into individually processed statistical maps per participant. It was built from a modified PETPrep-matlab pipeline to accommodate skipping some of the first steps since rCPS files were already provided to this pipeline and we did not want to re-create them.


### PR DESCRIPTION
I would like to update the description to make it clear that this is the petprep-matlab version that has been used/modified, as I am also working on a python implementation using the nipreps framework (similar to fmriprep). 